### PR TITLE
Do PoW for next chunk if at end of file or end of sector 

### DIFF
--- a/directories/src/redux/actions/treasure-hunt-actions.js
+++ b/directories/src/redux/actions/treasure-hunt-actions.js
@@ -1,6 +1,8 @@
 export const TREASURE_HUNT_CLAIM = "directories/treasure_hunt/claim";
 export const TREASURE_HUNT_CLAIM_SUCCESS =
   "directories/treasure_hunt/claim_success";
+export const TREASURE_HUNT_START_SECTOR =
+  "directories/treasure_hunt/start_sector";
 export const TREASURE_HUNT_PERFORM_POW =
   "directories/treasure_hunt/perform_pow";
 export const TREASURE_HUNT_FIND_TREASURE =
@@ -12,6 +14,7 @@ export const TREASURE_HUNT_INCREMENT_CHUNK =
 
 const ACTIONS = Object.freeze({
   // actions
+  TREASURE_HUNT_START_SECTOR,
   TREASURE_HUNT_PERFORM_POW,
   TREASURE_HUNT_CLAIM,
   TREASURE_HUNT_CLAIM_SUCCESS,
@@ -20,15 +23,18 @@ const ACTIONS = Object.freeze({
   TREASURE_HUNT_INCREMENT_CHUNK,
 
   // actionCreators
-  performPow: ({
+  startSector: ({
     address,
     message,
     genesisHash,
     sectorIdx,
     numberOfChunks
   }) => ({
-    type: TREASURE_HUNT_PERFORM_POW,
+    type: TREASURE_HUNT_START_SECTOR,
     payload: { address, genesisHash, sectorIdx, numberOfChunks }
+  }),
+  performPow: () => ({
+    type: TREASURE_HUNT_PERFORM_POW
   }),
   findTreasure: ({ address, chunkIdx }) => ({
     type: TREASURE_HUNT_FIND_TREASURE,
@@ -45,7 +51,6 @@ const ACTIONS = Object.freeze({
   claim: () => ({
     type: TREASURE_HUNT_CLAIM
   }),
-
   claimSuccess: () => ({
     type: TREASURE_HUNT_CLAIM_SUCCESS
   })

--- a/directories/src/redux/actions/treasure-hunt-actions.js
+++ b/directories/src/redux/actions/treasure-hunt-actions.js
@@ -1,6 +1,7 @@
-export const TREASURE_HUNT_CLAIM = "directories/treasure_hunt/claim";
-export const TREASURE_HUNT_CLAIM_SUCCESS =
-  "directories/treasure_hunt/claim_success";
+export const TREASURE_HUNT_CLAIM_TREASURE =
+  "directories/treasure_hunt/claim_treasure";
+export const TREASURE_HUNT_CLAIM_TREASURE_SUCCESS =
+  "directories/treasure_hunt/claim_treasure_success";
 export const TREASURE_HUNT_START_SECTOR =
   "directories/treasure_hunt/start_sector";
 export const TREASURE_HUNT_PERFORM_POW =
@@ -16,8 +17,8 @@ const ACTIONS = Object.freeze({
   // actions
   TREASURE_HUNT_START_SECTOR,
   TREASURE_HUNT_PERFORM_POW,
-  TREASURE_HUNT_CLAIM,
-  TREASURE_HUNT_CLAIM_SUCCESS,
+  TREASURE_HUNT_CLAIM_TREASURE,
+  TREASURE_HUNT_CLAIM_TREASURE_SUCCESS,
   TREASURE_HUNT_FIND_TREASURE,
   TREASURE_HUNT_SAVE_TREASURE,
   TREASURE_HUNT_INCREMENT_CHUNK,
@@ -48,11 +49,11 @@ const ACTIONS = Object.freeze({
     type: TREASURE_HUNT_INCREMENT_CHUNK,
     payload: { nextChunkIdx, nextDataMapHash }
   }),
-  claim: () => ({
-    type: TREASURE_HUNT_CLAIM
+  claimTreasure: () => ({
+    type: TREASURE_HUNT_CLAIM_TREASURE
   }),
-  claimSuccess: () => ({
-    type: TREASURE_HUNT_CLAIM_SUCCESS
+  claimTreasureSuccess: () => ({
+    type: TREASURE_HUNT_CLAIM_TREASURE_SUCCESS
   })
 });
 

--- a/directories/src/redux/actions/treasure-hunt-actions.js
+++ b/directories/src/redux/actions/treasure-hunt-actions.js
@@ -25,7 +25,7 @@ const ACTIONS = Object.freeze({
     numberOfChunks
   }) => ({
     type: TREASURE_HUNT_PERFORM_POW,
-    payload: { address, message, genesisHash, sectorIdx, numberOfChunks }
+    payload: { address, genesisHash, sectorIdx, numberOfChunks }
   }),
   findTreasure: ({ address, chunkIdx }) => ({
     type: TREASURE_HUNT_FIND_TREASURE,

--- a/directories/src/redux/actions/treasure-hunt-actions.js
+++ b/directories/src/redux/actions/treasure-hunt-actions.js
@@ -1,6 +1,6 @@
-export const TREASURE_HUNT_CLAIM = "directories/treasure_hunt/claim_treasure";
-export const TREASURE_HUNT_CLAIM_COMPLETE =
-  "directories/treasure_hunt/complete_claim_treasure";
+export const TREASURE_HUNT_CLAIM = "directories/treasure_hunt/claim";
+export const TREASURE_HUNT_CLAIM_SUCCESS =
+  "directories/treasure_hunt/claim_success";
 export const TREASURE_HUNT_PERFORM_POW =
   "directories/treasure_hunt/perform_pow";
 export const TREASURE_HUNT_FIND_TREASURE =
@@ -14,7 +14,7 @@ const ACTIONS = Object.freeze({
   // actions
   TREASURE_HUNT_PERFORM_POW,
   TREASURE_HUNT_CLAIM,
-  TREASURE_HUNT_CLAIM_COMPLETE,
+  TREASURE_HUNT_CLAIM_SUCCESS,
   TREASURE_HUNT_FIND_TREASURE,
   TREASURE_HUNT_SAVE_TREASURE,
   TREASURE_HUNT_INCREMENT_CHUNK,
@@ -42,12 +42,12 @@ const ACTIONS = Object.freeze({
     type: TREASURE_HUNT_INCREMENT_CHUNK,
     payload: { nextChunkIdx, nextAddress }
   }),
-  treasureClaim: () => ({
+  claim: () => ({
     type: TREASURE_HUNT_CLAIM
   }),
 
-  treasureClaimComplete: () => ({
-    type: TREASURE_HUNT_CLAIM_COMPLETE
+  claimSuccess: () => ({
+    type: TREASURE_HUNT_CLAIM_SUCCESS
   })
 });
 

--- a/directories/src/redux/actions/treasure-hunt-actions.js
+++ b/directories/src/redux/actions/treasure-hunt-actions.js
@@ -24,29 +24,29 @@ const ACTIONS = Object.freeze({
 
   // actionCreators
   startSector: ({
-    address,
+    dataMapHash,
     message,
     genesisHash,
     sectorIdx,
     numberOfChunks
   }) => ({
     type: TREASURE_HUNT_START_SECTOR,
-    payload: { address, genesisHash, sectorIdx, numberOfChunks }
+    payload: { dataMapHash, genesisHash, sectorIdx, numberOfChunks }
   }),
   performPow: () => ({
     type: TREASURE_HUNT_PERFORM_POW
   }),
-  findTreasure: ({ address, chunkIdx }) => ({
+  findTreasure: ({ dataMapHash, chunkIdx }) => ({
     type: TREASURE_HUNT_FIND_TREASURE,
-    payload: { address, chunkIdx }
+    payload: { dataMapHash, chunkIdx }
   }),
-  saveTreasure: ({ treasure, nextChunkIdx, nextAddress }) => ({
+  saveTreasure: ({ treasure, nextChunkIdx, nextDataMapHash }) => ({
     type: TREASURE_HUNT_SAVE_TREASURE,
-    payload: { treasure, nextChunkIdx, nextAddress }
+    payload: { treasure, nextChunkIdx, nextDataMapHash }
   }),
-  incrementChunk: ({ nextChunkIdx, nextAddress }) => ({
+  incrementChunk: ({ nextChunkIdx, nextDataMapHash }) => ({
     type: TREASURE_HUNT_INCREMENT_CHUNK,
-    payload: { nextChunkIdx, nextAddress }
+    payload: { nextChunkIdx, nextDataMapHash }
   }),
   claim: () => ({
     type: TREASURE_HUNT_CLAIM

--- a/directories/src/redux/actions/treasure-hunt-actions.js
+++ b/directories/src/redux/actions/treasure-hunt-actions.js
@@ -7,6 +7,8 @@ export const TREASURE_HUNT_FIND_TREASURE =
   "directories/treasure_hunt/find_treasure";
 export const TREASURE_HUNT_SAVE_TREASURE =
   "directories/treasure_hunt/save_treasure";
+export const TREASURE_HUNT_INCREMENT_CHUNK =
+  "directories/treasure_hunt/increment_chunk";
 
 const ACTIONS = Object.freeze({
   // actions
@@ -15,6 +17,7 @@ const ACTIONS = Object.freeze({
   TREASURE_HUNT_CLAIM_COMPLETE,
   TREASURE_HUNT_FIND_TREASURE,
   TREASURE_HUNT_SAVE_TREASURE,
+  TREASURE_HUNT_INCREMENT_CHUNK,
 
   // actionCreators
   performPow: ({
@@ -31,9 +34,13 @@ const ACTIONS = Object.freeze({
     type: TREASURE_HUNT_FIND_TREASURE,
     payload: { address, chunkIdx }
   }),
-  saveTreasure: ({ treasure, nextChunkIdx }) => ({
+  saveTreasure: ({ treasure, nextChunkIdx, nextAddress }) => ({
     type: TREASURE_HUNT_SAVE_TREASURE,
-    payload: { treasure, nextChunkIdx }
+    payload: { treasure, nextChunkIdx, nextAddress }
+  }),
+  incrementChunk: ({ nextChunkIdx, nextAddress }) => ({
+    type: TREASURE_HUNT_INCREMENT_CHUNK,
+    payload: { nextChunkIdx, nextAddress }
   }),
   treasureClaim: () => ({
     type: TREASURE_HUNT_CLAIM

--- a/directories/src/redux/epics/node-epics.js
+++ b/directories/src/redux/epics/node-epics.js
@@ -220,7 +220,6 @@ const checkIfSectorClaimedEpic = (action$, store) => {
         } else {
           return treasureHuntActions.performPow({
             address,
-            message: transaction.signatureMessageFragment,
             genesisHash,
             numberOfChunks,
             sectorIdx

--- a/directories/src/redux/epics/node-epics.js
+++ b/directories/src/redux/epics/node-epics.js
@@ -204,8 +204,9 @@ const checkIfSectorClaimedEpic = (action$, store) => {
     .mergeMap(action => {
       const { genesisHash, numberOfChunks, sectorIdx } = action.payload;
       const specialChunkIdx = sectorIdx * CHUNKS_PER_SECTOR;
-      const dataMap = Datamap.generate(genesisHash, numberOfChunks);
-      // const address = dataMap[specialChunkIdx];
+      const dataMap = Datamap.rawGenerate(genesisHash, numberOfChunks);
+      // const rawHash = dataMap[specialChunkIdx];
+      // const address = Datamap.obfuscate(rawHash);
       const address =
         "HT9MZQXKVBVT9AYVTISCLELYWXTILJDIMHFQRGS9YIJUIRSSNRZFIZCHYHQHKZIPGYYCSUSARFNSXD9UY";
 

--- a/directories/src/redux/epics/node-epics.js
+++ b/directories/src/redux/epics/node-epics.js
@@ -205,7 +205,7 @@ const checkIfSectorClaimedEpic = (action$, store) => {
       const { genesisHash, numberOfChunks, sectorIdx } = action.payload;
       const specialChunkIdx = sectorIdx * CHUNKS_PER_SECTOR;
       const dataMap = Datamap.rawGenerate(genesisHash, numberOfChunks);
-      // const rawHash = dataMap[specialChunkIdx];
+      const dataMapHash = dataMap[specialChunkIdx];
       // const address = Datamap.obfuscate(rawHash);
       const address =
         "HT9MZQXKVBVT9AYVTISCLELYWXTILJDIMHFQRGS9YIJUIRSSNRZFIZCHYHQHKZIPGYYCSUSARFNSXD9UY";
@@ -220,7 +220,7 @@ const checkIfSectorClaimedEpic = (action$, store) => {
           });
         } else {
           return treasureHuntActions.startSector({
-            address,
+            dataMapHash,
             genesisHash,
             numberOfChunks,
             sectorIdx

--- a/directories/src/redux/epics/node-epics.js
+++ b/directories/src/redux/epics/node-epics.js
@@ -218,7 +218,7 @@ const checkIfSectorClaimedEpic = (action$, store) => {
             sectorIdx
           });
         } else {
-          return treasureHuntActions.performPow({
+          return treasureHuntActions.startSector({
             address,
             genesisHash,
             numberOfChunks,

--- a/directories/src/redux/epics/treasure-hunt-epics.js
+++ b/directories/src/redux/epics/treasure-hunt-epics.js
@@ -114,6 +114,7 @@ const findTreasureEpic = (action$, store) => {
 const nextChunkEpic = (action$, store) => {
   return action$
     .ofType(
+      treasureHuntActions.TREASURE_HUNT_START_SECTOR,
       treasureHuntActions.TREASURE_HUNT_SAVE_TREASURE,
       treasureHuntActions.TREASURE_HUNT_INCREMENT_CHUNK
     )
@@ -123,10 +124,11 @@ const nextChunkEpic = (action$, store) => {
 
       const endOfFile = chunkIdx > numberOfChunks;
       const endOfSector = chunkIdx > CHUNKS_PER_SECTOR * (sectorIdx + 1);
+
       return Observable.if(
         () => endOfFile || endOfSector,
         Observable.of(treasureHuntActions.claim()),
-        Observable.of(treasureHuntActions.claim())
+        Observable.of(treasureHuntActions.performPow())
       );
     });
 };

--- a/directories/src/redux/epics/treasure-hunt-epics.js
+++ b/directories/src/redux/epics/treasure-hunt-epics.js
@@ -15,7 +15,6 @@ const performPowEpic = (action$, store) => {
   return action$
     .ofType(treasureHuntActions.TREASURE_HUNT_PERFORM_POW)
     .mergeMap(action => {
-      console.log("pppppppppppppppp");
       const { treasureHunt } = store.getState();
       const { dataMapHash, treasure, chunkIdx, numberOfChunks } = treasureHunt;
 
@@ -136,7 +135,7 @@ const nextChunkEpic = (action$, store) => {
 
       return Observable.if(
         () => endOfFile || endOfSector,
-        Observable.of(treasureHuntActions.claim()),
+        Observable.of(treasureHuntActions.claimTreasure()),
         Observable.of(treasureHuntActions.performPow())
       );
     });

--- a/directories/src/redux/epics/treasure-hunt-epics.js
+++ b/directories/src/redux/epics/treasure-hunt-epics.js
@@ -97,6 +97,13 @@ const findTreasureEpic = (action$, store) => {
               nextChunkIdx: chunkIdx + 1,
               nextAddress
             })
+          ),
+          Observable.of(
+            treasureHuntActions.incrementChunk({
+              treasure,
+              nextChunkIdx: chunkIdx + 1,
+              nextAddress
+            })
           )
         );
       });

--- a/directories/src/redux/epics/treasure-hunt-epics.js
+++ b/directories/src/redux/epics/treasure-hunt-epics.js
@@ -15,8 +15,13 @@ const performPowEpic = (action$, store) => {
   return action$
     .ofType(treasureHuntActions.TREASURE_HUNT_PERFORM_POW)
     .mergeMap(action => {
+      console.log("pppppppppppppppp");
       const { treasureHunt } = store.getState();
-      const { address, treasure, chunkIdx, numberOfChunks } = treasureHunt;
+      const { dataMapHash, treasure, chunkIdx, numberOfChunks } = treasureHunt;
+
+      // const address = Encryption.obfuscate(dataMapHash);
+      const address =
+        "HT9MZQXKVBVT9AYVTISCLELYWXTILJDIMHFQRGS9YIJUIRSSNRZFIZCHYHQHKZIPGYYCSUSARFNSXD9UY";
 
       // TODO: change this
       const value = 0;
@@ -60,7 +65,7 @@ const performPowEpic = (action$, store) => {
             () => !treasure,
             Observable.of(
               treasureHuntActions.findTreasure({
-                address,
+                dataMapHash,
                 chunkIdx
               })
             )
@@ -77,7 +82,11 @@ const findTreasureEpic = (action$, store) => {
   return action$
     .ofType(treasureHuntActions.TREASURE_HUNT_FIND_TREASURE)
     .mergeMap(action => {
-      const { address, chunkIdx } = action.payload;
+      const { dataMapHash, chunkIdx } = action.payload;
+
+      // const address = Encryption.obfuscate(dataMapHash);
+      const address =
+        "HT9MZQXKVBVT9AYVTISCLELYWXTILJDIMHFQRGS9YIJUIRSSNRZFIZCHYHQHKZIPGYYCSUSARFNSXD9UY";
 
       return Observable.fromPromise(
         iota.findMostRecentTransaction(address)
@@ -89,7 +98,7 @@ const findTreasureEpic = (action$, store) => {
           hashedAddress => !!Encryption.decrypt(message, hashedAddress)
         );
 
-        const [_obfHash, nextAddress] = Encryption.hashChain(address);
+        const [_obfHash, nextDataMapHash] = Encryption.hashChain(dataMapHash);
 
         return Observable.if(
           () => !!treasure,
@@ -97,13 +106,13 @@ const findTreasureEpic = (action$, store) => {
             treasureHuntActions.saveTreasure({
               treasure,
               nextChunkIdx: chunkIdx + 1,
-              nextAddress
+              nextDataMapHash
             })
           ),
           Observable.of(
             treasureHuntActions.incrementChunk({
               nextChunkIdx: chunkIdx + 1,
-              nextAddress
+              nextDataMapHash
             })
           )
         );

--- a/directories/src/redux/reducers/treasure-hunt-reducer.js
+++ b/directories/src/redux/reducers/treasure-hunt-reducer.js
@@ -45,7 +45,10 @@ export default (state = initState, action) => {
       }
 
     case TREASURE_HUNT_INCREMENT_CHUNK:
-      const { nextChunkIdx: nxtChunkIdx, nextAddr } = action.payload;
+      const {
+        nextChunkIdx: nxtChunkIdx,
+        nextAddress: nextAddr
+      } = action.payload;
       return {
         ...state,
         chunkIdx: nxtChunkIdx,

--- a/directories/src/redux/reducers/treasure-hunt-reducer.js
+++ b/directories/src/redux/reducers/treasure-hunt-reducer.js
@@ -1,5 +1,5 @@
 import {
-  TREASURE_HUNT_PERFORM_POW,
+  TREASURE_HUNT_START_SECTOR,
   TREASURE_HUNT_FIND_TREASURE,
   TREASURE_HUNT_SAVE_TREASURE,
   TREASURE_HUNT_INCREMENT_CHUNK
@@ -18,7 +18,7 @@ const initState = {
 
 export default (state = initState, action) => {
   switch (action.type) {
-    case TREASURE_HUNT_PERFORM_POW:
+    case TREASURE_HUNT_START_SECTOR:
       const {
         address,
         genesisHash,

--- a/directories/src/redux/reducers/treasure-hunt-reducer.js
+++ b/directories/src/redux/reducers/treasure-hunt-reducer.js
@@ -1,7 +1,8 @@
 import {
   TREASURE_HUNT_PERFORM_POW,
   TREASURE_HUNT_FIND_TREASURE,
-  TREASURE_HUNT_SAVE_TREASURE
+  TREASURE_HUNT_SAVE_TREASURE,
+  TREASURE_HUNT_INCREMENT_CHUNK
 } from "../actions/treasure-hunt-actions";
 
 import { CHUNKS_PER_SECTOR } from "../../config/";
@@ -42,6 +43,14 @@ export default (state = initState, action) => {
           chunkIdx: sectorStartingIdx
         };
       }
+
+    case TREASURE_HUNT_INCREMENT_CHUNK:
+      const { nextChunkIdx: nxtChunkIdx, nextAddr } = action.payload;
+      return {
+        ...state,
+        chunkIdx: nxtChunkIdx,
+        address: nextAddr
+      };
 
     case TREASURE_HUNT_SAVE_TREASURE:
       const { treasure, nextChunkIdx, nextAddress } = action.payload;

--- a/directories/src/redux/reducers/treasure-hunt-reducer.js
+++ b/directories/src/redux/reducers/treasure-hunt-reducer.js
@@ -8,7 +8,7 @@ import {
 import { CHUNKS_PER_SECTOR } from "../../config/";
 
 const initState = {
-  address: null,
+  dataMapHash: null,
   genesisHash: null,
   chunkIdx: 0,
   numberOfChunks: 1,
@@ -20,7 +20,7 @@ export default (state = initState, action) => {
   switch (action.type) {
     case TREASURE_HUNT_START_SECTOR:
       const {
-        address,
+        dataMapHash,
         genesisHash,
         sectorIdx,
         numberOfChunks
@@ -35,7 +35,7 @@ export default (state = initState, action) => {
         const sectorStartingIdx = sectorIdx * CHUNKS_PER_SECTOR;
         return {
           ...state,
-          address,
+          dataMapHash,
           genesisHash,
           sectorIdx,
           numberOfChunks,
@@ -47,21 +47,21 @@ export default (state = initState, action) => {
     case TREASURE_HUNT_INCREMENT_CHUNK:
       const {
         nextChunkIdx: nxtChunkIdx,
-        nextAddress: nextAddr
+        nextDataMapHash: nextDataMapHsh
       } = action.payload;
       return {
         ...state,
         chunkIdx: nxtChunkIdx,
-        address: nextAddr
+        dataMapHash: nextDataMapHsh
       };
 
     case TREASURE_HUNT_SAVE_TREASURE:
-      const { treasure, nextChunkIdx, nextAddress } = action.payload;
+      const { treasure, nextChunkIdx, nextDataMapHash } = action.payload;
       return {
         ...state,
         treasure,
         chunkIdx: nextChunkIdx,
-        address: nextAddress
+        dataMapHash: nextDataMapHash
       };
 
     default:

--- a/directories/src/redux/reducers/treasure-hunt-reducer.js
+++ b/directories/src/redux/reducers/treasure-hunt-reducer.js
@@ -9,7 +9,6 @@ import { CHUNKS_PER_SECTOR } from "../../config/";
 const initState = {
   address: null,
   genesisHash: null,
-  message: null,
   chunkIdx: 0,
   numberOfChunks: 1,
   sectorIdx: 0,
@@ -21,7 +20,6 @@ export default (state = initState, action) => {
     case TREASURE_HUNT_PERFORM_POW:
       const {
         address,
-        message,
         genesisHash,
         sectorIdx,
         numberOfChunks
@@ -37,7 +35,6 @@ export default (state = initState, action) => {
         return {
           ...state,
           address,
-          message,
           genesisHash,
           sectorIdx,
           numberOfChunks,

--- a/directories/src/redux/reducers/treasure-hunt-reducer.js
+++ b/directories/src/redux/reducers/treasure-hunt-reducer.js
@@ -44,11 +44,12 @@ export default (state = initState, action) => {
       }
 
     case TREASURE_HUNT_SAVE_TREASURE:
-      const { treasure, nextChunkIdx } = action.payload;
+      const { treasure, nextChunkIdx, nextAddress } = action.payload;
       return {
         ...state,
         treasure,
-        chunkIdx: nextChunkIdx
+        chunkIdx: nextChunkIdx,
+        address: nextAddress
       };
 
     default:

--- a/directories/src/redux/services/iota.js
+++ b/directories/src/redux/services/iota.js
@@ -43,8 +43,9 @@ const findMostRecentTransaction = address =>
     iotaProvider.api.findTransactionObjects(
       { addresses: [address] },
       (error, transactionObjects) => {
-        if (error) {
+        if (error || !transactionObjects) {
           console.log("IOTA ERROR: ", error);
+          reject(new Error("No transaction found"));
         }
         const settledTransactions = transactionObjects || [];
         const recentTransaction = _.maxBy(

--- a/directories/src/utils/datamap.js
+++ b/directories/src/utils/datamap.js
@@ -2,23 +2,6 @@ import _ from "lodash";
 import iota from "redux/services/iota";
 import Encryption from "utils/encryption";
 
-// const generate = (handle, size) => {
-// const keys = _.range(0, size + 1);
-
-// const [dataMap, _hash] = _.reduce(
-// keys,
-// ([dataM, hash], i) => {
-// const [obfuscatedHash, nextHash] = Encryption.hashChain(hash);
-// dataM[i] = iota.toAddress(iota.utils.toTrytes(obfuscatedHash));
-
-// return [dataM, nextHash];
-// },
-// [{}, Encryption.genesisHash(handle)]
-// );
-
-// return dataMap;
-// };
-
 const rawGenerate = (handle, size) => {
   const keys = _.range(0, size + 1);
 

--- a/directories/src/utils/datamap.js
+++ b/directories/src/utils/datamap.js
@@ -2,14 +2,31 @@ import _ from "lodash";
 import iota from "redux/services/iota";
 import Encryption from "utils/encryption";
 
-const generate = (handle, size) => {
+// const generate = (handle, size) => {
+// const keys = _.range(0, size + 1);
+
+// const [dataMap, _hash] = _.reduce(
+// keys,
+// ([dataM, hash], i) => {
+// const [obfuscatedHash, nextHash] = Encryption.hashChain(hash);
+// dataM[i] = iota.toAddress(iota.utils.toTrytes(obfuscatedHash));
+
+// return [dataM, nextHash];
+// },
+// [{}, Encryption.genesisHash(handle)]
+// );
+
+// return dataMap;
+// };
+
+const rawGenerate = (handle, size) => {
   const keys = _.range(0, size + 1);
 
   const [dataMap, _hash] = _.reduce(
     keys,
     ([dataM, hash], i) => {
-      const [obfuscatedHash, nextHash] = Encryption.hashChain(hash);
-      dataM[i] = iota.toAddress(iota.utils.toTrytes(obfuscatedHash));
+      const [_obfuscatedHash, nextHash] = Encryption.hashChain(hash);
+      dataM[i] = nextHash;
 
       return [dataM, nextHash];
     },
@@ -19,4 +36,4 @@ const generate = (handle, size) => {
   return dataMap;
 };
 
-export default { generate };
+export default { rawGenerate };

--- a/directories/src/utils/encryption.js
+++ b/directories/src/utils/encryption.js
@@ -21,6 +21,8 @@ const getPrimordialHash = () => {
   return CryptoJS.SHA256(entropy).toString();
 };
 
+const obfuscate = hash => CryptoJS.SHA384(hash).toString();
+
 // Returns [obfuscatedHash, nextHash]
 const hashChain = hash => {
   const obfuscatedHash = CryptoJS.SHA384(hash).toString();
@@ -56,6 +58,7 @@ export default {
   getPrimordialHash,
   getSalt,
   hashChain,
+  obfuscate,
   parseEightCharsOfFilename,
   sideChain
 };


### PR DESCRIPTION
- Unless the sector is finished or we're at the end of the file, continue doing PoW for the next chunk
- Pass around the datamap hash value instead of an address so that we can derive the following address from it by calling `Encryption.obfuscate(dataMapHash)` instead of recreating the datamap
- Merge flows for starting sector, saving treasure, incrementing chunks

Next PR: Claim sector if at end of sector or end of file, unhappy path