### PR TITLE
Remove ethAddr from webnode

### DIFF
--- a/webnode/src/config/index.js
+++ b/webnode/src/config/index.js
@@ -3,7 +3,7 @@ export const API_VERSION = "api/v2";
 export const API_ROOT_URL =
   window.location.href.indexOf("localhost") > 0
     ? "http://localhost:3000"
-    : "http://18.217.131.231:3000";
+    : "http://18.188.64.13:3000";
 export const API_HEADERS = ["Content-type : application/json"];
 export const API_REQUEST_ERROR = "API_REQUEST_ERROR";
 

--- a/webnode/src/redux/epics/treasure-hunt-epics.js
+++ b/webnode/src/redux/epics/treasure-hunt-epics.js
@@ -184,7 +184,7 @@ const claimTreasureEpic = (action$, store) => {
         sectorIdx,
         treasure
       } = action.payload;
-      const { ethKey, ethAddr } = treasure;
+      const ethKey = treasure;
 
       return Observable.fromPromise(
         BrokerNode.claimTreasure({
@@ -192,8 +192,7 @@ const claimTreasureEpic = (action$, store) => {
           genesisHash,
           numChunks,
           sectorIdx,
-          ethKey,
-          ethAddr
+          ethKey
         })
       )
         .map(() =>

--- a/webnode/src/redux/services/broker-node.js
+++ b/webnode/src/redux/services/broker-node.js
@@ -37,7 +37,6 @@ const completeGenesisHashPoW = (txid, trytes) =>
   });
 
 const claimTreasure = ({
-  ethAddr,
   ethKey,
   genesisHash,
   numChunks,
@@ -46,9 +45,8 @@ const claimTreasure = ({
 }) =>
   axios({
     method: "POST",
-    url: `${API_ROOT_URL}/${API_VERSION}/supply/treasures`,
+    url: `${API_ROOT_URL}/${API_VERSION}/treasures`,
     data: {
-      ethAddr,
       ethKey,
       genesisHash,
       numChunks,


### PR DESCRIPTION
This removes the ethAddr from the webnode, since the brokernode is able to generate the eth address just from the private key.  

When I hardcoded in my broker's IP and ran the app with a genesis hash, I saw that the request was getting to the broker successfully with the parameters expected, except that the genesisHash parameter was null. 

