### PR TITLE
Resume sector or start new

### DIFF
--- a/webnode/config/webpack.config.dev.js
+++ b/webnode/config/webpack.config.dev.js
@@ -15,7 +15,7 @@ const env = getClientEnvironment(publicUrl);
 
 module.exports = {
   devServer: {
-    port: 3000,
+    port: 3001,
     open: true,
     clientLogLevel: "none"
   },

--- a/webnode/src/redux/actions/node-actions.js
+++ b/webnode/src/redux/actions/node-actions.js
@@ -14,6 +14,8 @@ export const NODE_ADD_BROKER_NODE = "directories/node/add_broker_node";
 export const NODE_ADD_NEW_GENESIS_HASH =
   "directories/node/add_new_genesis_hash";
 export const NODE_RESET = "directories/node/reset";
+export const NODE_RESUME_OR_START_NEW_SECTOR =
+  "directories/node/resume_or_start_new_sector";
 export const NODE_CHECK_IF_SECTOR_CLAIMED =
   "directories/node/check_if_sector_claimed";
 export const NODE_MARK_SECTOR_AS_CLAIMED =
@@ -30,6 +32,7 @@ const ACTIONS = Object.freeze({
   NODE_ADD_BROKER_NODE,
   NODE_ADD_NEW_GENESIS_HASH,
   NODE_RESET,
+  NODE_RESUME_OR_START_NEW_SECTOR,
   NODE_CHECK_IF_SECTOR_CLAIMED,
   NODE_MARK_SECTOR_AS_CLAIMED,
 
@@ -63,6 +66,11 @@ const ACTIONS = Object.freeze({
   resetNode: ({ id, lastResetAt }) => ({
     type: NODE_RESET,
     payload: { id, lastResetAt }
+  }),
+
+  resumeOrStartNewSector: ({ genesisHash, sectorIdx, numberOfChunks }) => ({
+    type: NODE_RESUME_OR_START_NEW_SECTOR,
+    payload: { genesisHash, sectorIdx, numberOfChunks }
   }),
 
   checkIfSectorClaimed: ({ genesisHash, sectorIdx, numberOfChunks }) => ({

--- a/webnode/src/redux/epics/node-epics.js
+++ b/webnode/src/redux/epics/node-epics.js
@@ -282,6 +282,7 @@ export default combineEpics(
   genesisHashOrTreasureHuntEpic,
   requestBrokerEpic,
   requestGenesisHashEpic,
+  resumeOrStartNewSectorEpic,
   checkIfSectorClaimedEpic,
   markSectorAsClaimedEpic
 );

--- a/webnode/src/redux/epics/node-epics.js
+++ b/webnode/src/redux/epics/node-epics.js
@@ -1,6 +1,6 @@
-import { fromPromise } from 'rxjs/observable/fromPromise';
-import { of } from 'rxjs/observable/of';
-import { empty } from 'rxjs/observable/empty';
+import { fromPromise } from "rxjs/observable/fromPromise";
+import { of } from "rxjs/observable/of";
+import { empty } from "rxjs/observable/empty";
 
 import { combineEpics } from "redux-observable";
 
@@ -16,7 +16,7 @@ import Datamap from "datamap-generator";
 import {
   MIN_GENESIS_HASHES,
   MIN_BROKER_NODES,
-  CHUNKS_PER_SECTOR,
+  CHUNKS_PER_SECTOR
 } from "../../config/";
 
 const registerWebnodeEpic = (action$, store) => {
@@ -75,13 +75,39 @@ const genesisHashOrTreasureHuntEpic = (action$, store) => {
         const { genesisHash, numberOfChunks } = treasureHuntableGenesisHash;
         const { index } = treasureHuntableSector;
         return of(
-          nodeActions.checkIfSectorClaimed({
+          nodeActions.resumeOrStartNewSector({
             genesisHash: genesisHash,
             numberOfChunks: numberOfChunks,
             sectorIdx: index
           })
         );
       }
+    });
+};
+
+const resumeOrStartNewSectorEpic = (action$, store) => {
+  return action$
+    .ofType(nodeActions.NODE_RESUME_OR_START_NEW_SECTOR)
+    .mergeMap(action => {
+      const { genesisHash, numberOfChunks, sectorIdx } = action.payload;
+      const {
+        chunkIdx,
+        sectorIdx: currentSectorIdx
+      } = store.getState().treasureHunt;
+      const sectorsFirstChunkIdx = sectorIdx * CHUNKS_PER_SECTOR;
+
+      const alreadyStartedSector =
+        chunkIdx > sectorsFirstChunkIdx && currentSectorIdx === sectorIdx;
+
+      return alreadyStartedSector
+        ? of(treasureHuntActions.performPow())
+        : of(
+            nodeActions.checkIfSectorClaimed({
+              genesisHash,
+              numberOfChunks,
+              sectorIdx
+            })
+          );
     });
 };
 
@@ -95,10 +121,7 @@ const requestBrokerEpic = (action$, store) => {
       brokerNode.requestBrokerNodeAddressPoW({ brokerNodeUrl, currentList })
     )
       .mergeMap(({ data }) => {
-        const {
-          id: txid,
-          pow: { message, address, branchTx, trunkTx }
-        } = data;
+        const { id: txid, pow: { message, address, branchTx, trunkTx } } = data;
 
         // TODO: change this
         const value = 0;

--- a/webnode/src/redux/epics/treasure-hunt-epics.js
+++ b/webnode/src/redux/epics/treasure-hunt-epics.js
@@ -1,6 +1,6 @@
-import { fromPromise } from 'rxjs/observable/fromPromise';
-import { of } from 'rxjs/observable/of';
-import { empty } from 'rxjs/observable/empty';
+import { fromPromise } from "rxjs/observable/fromPromise";
+import { of } from "rxjs/observable/of";
+import { empty } from "rxjs/observable/empty";
 import { combineEpics } from "redux-observable"; //TODO remove store as dependency
 
 import _ from "lodash";
@@ -94,41 +94,41 @@ const findTreasureEpic = (action$, store) => {
       const nextDataMapHash = forge.util.bytesToHex(nextDataMapHashInBytes);
       const address = iota.toAddress(iota.utils.toTrytes(obfuscatedHash));
 
-      return fromPromise(
-        iota.findMostRecentTransaction(address)
-      ).mergeMap(transaction => {
-        const sideChain = Datamap.sideChainGenerate(dataMapHash);
+      return fromPromise(iota.findMostRecentTransaction(address)).mergeMap(
+        transaction => {
+          const sideChain = Datamap.sideChainGenerate(dataMapHash);
 
-        store.dispatch({
-          //TODO Remove this dispatch
-          type: "IOTA_RETURN"
-        });
+          store.dispatch({
+            //TODO Remove this dispatch
+            type: "IOTA_RETURN"
+          });
 
-        const chainWithTreasure = _.find(sideChain, hashedAddress => {
-          return !!Datamap.decryptTreasure(
-            hashedAddress,
-            transaction.signatureMessageFragment,
-            dataMapHash
+          const chainWithTreasure = _.find(sideChain, hashedAddress => {
+            return !!Datamap.decryptTreasure(
+              hashedAddress,
+              transaction.signatureMessageFragment,
+              dataMapHash
+            );
+          });
+
+          return of(
+            !!chainWithTreasure
+              ? treasureHuntActions.saveTreasure({
+                  treasure: Datamap.decryptTreasure(
+                    chainWithTreasure,
+                    transaction.signatureMessageFragment,
+                    dataMapHash
+                  ),
+                  nextChunkIdx: chunkIdx + 1,
+                  nextDataMapHash
+                })
+              : treasureHuntActions.incrementChunk({
+                  nextChunkIdx: chunkIdx + 1,
+                  nextDataMapHash
+                })
           );
-        });
-
-        return of(
-          !!chainWithTreasure
-            ? treasureHuntActions.saveTreasure({
-                treasure: Datamap.decryptTreasure(
-                  chainWithTreasure,
-                  transaction.signatureMessageFragment,
-                  dataMapHash
-                ),
-                nextChunkIdx: chunkIdx + 1,
-                nextDataMapHash
-              })
-            : treasureHuntActions.incrementChunk({
-                nextChunkIdx: chunkIdx + 1,
-                nextDataMapHash
-              })
-        );
-      });
+        }
+      );
     });
 };
 
@@ -174,7 +174,7 @@ const claimTreasureEpic = (action$, store) => {
       const {
         receiverEthAddr,
         genesisHash,
-        numChunks,
+        numberOfChunks,
         sectorIdx,
         treasure
       } = action.payload;
@@ -184,7 +184,7 @@ const claimTreasureEpic = (action$, store) => {
         BrokerNode.claimTreasure({
           receiverEthAddr,
           genesisHash,
-          numChunks,
+          numberOfChunks,
           sectorIdx,
           ethKey
         })

--- a/webnode/src/redux/services/broker-node.js
+++ b/webnode/src/redux/services/broker-node.js
@@ -39,7 +39,7 @@ const completeGenesisHashPoW = ({ brokerNodeUrl, txid, trytes }) =>
 const claimTreasure = ({
   ethKey,
   genesisHash,
-  numChunks,
+  numberOfChunks,
   receiverEthAddr,
   sectorIdx
 }) =>
@@ -49,7 +49,7 @@ const claimTreasure = ({
     data: {
       ethKey,
       genesisHash,
-      numChunks,
+      numChunks: numberOfChunks,
       receiverEthAddr,
       sectorIdx
     }


### PR DESCRIPTION
- Fix logic for resuming a sector. It used to look at the 1st chunk of the sector but that wouldn't work because it would already have been reattached by itself. Instead, just resume if we're in the same sector + not at the first chunk of that sector.