### PR TITLE
Unhappy path for when no treasure is found in sector (edge case)

### DIFF
--- a/webnode/src/config/index.js
+++ b/webnode/src/config/index.js
@@ -3,12 +3,12 @@ export const DEBUGGING = process.env.DEBUG;
 export const API_VERSION = "api/v2";
 
 export const API_ROOT_URL =
-  (window.location && window.location.href.indexOf('localhost') > 0) > 0
+  (window.location && window.location.href.indexOf("localhost") > 0) > 0
     ? "http://18.217.133.146:3000"
     : "https://broker-1.oysternodes.com:3000";
 
 export const ASSET_URL =
-  (window.location && window.location.href.indexOf('localhost') > 0) > 0
+  (window.location && window.location.href.indexOf("localhost") > 0) > 0
     ? window.location.href
     : "https://web.oysternode.com/";
 
@@ -22,7 +22,8 @@ export const MIN_GENESIS_HASHES = 1;
 
 export const SECTOR_STATUS = {
   CLAIMED: "CLAIMED",
-  UNCLAIMED: "UNCLAIMED"
+  UNCLAIMED: "UNCLAIMED",
+  NO_TREASURE_FOUND: "NO_TREASURE_FOUND"
 };
 
 export const CONSENT_STATUS = {

--- a/webnode/src/redux/actions/node-actions.js
+++ b/webnode/src/redux/actions/node-actions.js
@@ -18,7 +18,7 @@ export const NODE_RESUME_OR_START_NEW_SECTOR =
   "directories/node/resume_or_start_new_sector";
 export const NODE_CHECK_IF_SECTOR_CLAIMED =
   "directories/node/check_if_sector_claimed";
-export const NODE_MARK_SECTOR_AS_CLAIMED =
+export const NODE_UPDATE_SECTOR_STATUS =
   "directories/node/mark_sector_as_claimed";
 
 const ACTIONS = Object.freeze({
@@ -34,7 +34,7 @@ const ACTIONS = Object.freeze({
   NODE_RESET,
   NODE_RESUME_OR_START_NEW_SECTOR,
   NODE_CHECK_IF_SECTOR_CLAIMED,
-  NODE_MARK_SECTOR_AS_CLAIMED,
+  NODE_UPDATE_SECTOR_STATUS,
 
   // actionCreators
   determineBrokerNodeOrGenesisHash: () => ({
@@ -78,9 +78,9 @@ const ACTIONS = Object.freeze({
     payload: { genesisHash, sectorIdx, numberOfChunks }
   }),
 
-  markSectorAsClaimed: ({ genesisHash, sectorIdx }) => ({
-    type: NODE_MARK_SECTOR_AS_CLAIMED,
-    payload: { genesisHash, sectorIdx }
+  updateSectorStatus: ({ genesisHash, sectorIdx, status }) => ({
+    type: NODE_UPDATE_SECTOR_STATUS,
+    payload: { genesisHash, sectorIdx, status }
   }),
 
   setOwnerEthAddress: ethAddress => ({

--- a/webnode/src/redux/actions/node-actions.test.js
+++ b/webnode/src/redux/actions/node-actions.test.js
@@ -1,4 +1,7 @@
 import actions from "./node-actions";
+import { SECTOR_STATUS } from "../../config/";
+
+const { CLAIMED } = SECTOR_STATUS;
 
 test("node-action NODE_DETERMINE_BROKER_NODE_OR_GENESIS_HASH", () => {
   const expected = {
@@ -84,17 +87,19 @@ test("node-action NODE_CHECK_IF_SECTOR_CLAIMED", () => {
   ).toEqual(expected);
 });
 
-test("node-action NODE_MARK_SECTOR_AS_CLAIMED", () => {
+test("node-action NODE_UPDATE_SECTOR_STATUS", () => {
   const genesisHash = "address";
   const sectorIdx = 2;
+  const status = CLAIMED;
   const expected = {
-    type: actions.NODE_MARK_SECTOR_AS_CLAIMED,
+    type: actions.NODE_UPDATE_SECTOR_STATUS,
     payload: {
-      genesisHash: genesisHash,
-      sectorIdx: sectorIdx
+      genesisHash,
+      sectorIdx,
+      status
     }
   };
-  expect(actions.markSectorAsClaimed({ genesisHash, sectorIdx })).toEqual(
-    expected
-  );
+  expect(
+    actions.updateSectorStatus({ genesisHash, sectorIdx, status })
+  ).toEqual(expected);
 });

--- a/webnode/src/redux/actions/treasure-hunt-actions.js
+++ b/webnode/src/redux/actions/treasure-hunt-actions.js
@@ -2,6 +2,8 @@ export const TREASURE_HUNT_CLAIM_TREASURE =
   "directories/treasure_hunt/claim_treasure";
 export const TREASURE_HUNT_CLAIM_TREASURE_SUCCESS =
   "directories/treasure_hunt/claim_treasure_success";
+export const TREASURE_HUNT_CLAIM_TREASURE_FAILURE =
+  "directories/treasure_hunt/claim_treasure_failure";
 export const TREASURE_HUNT_START_SECTOR =
   "directories/treasure_hunt/start_sector";
 export const TREASURE_HUNT_PERFORM_POW =
@@ -19,6 +21,7 @@ const ACTIONS = Object.freeze({
   TREASURE_HUNT_PERFORM_POW,
   TREASURE_HUNT_CLAIM_TREASURE,
   TREASURE_HUNT_CLAIM_TREASURE_SUCCESS,
+  TREASURE_HUNT_CLAIM_TREASURE_FAILURE,
   TREASURE_HUNT_FIND_TREASURE,
   TREASURE_HUNT_SAVE_TREASURE,
   TREASURE_HUNT_INCREMENT_CHUNK,
@@ -67,6 +70,10 @@ const ACTIONS = Object.freeze({
   }),
   claimTreasureSuccess: ({ genesisHash, sectorIdx }) => ({
     type: TREASURE_HUNT_CLAIM_TREASURE_SUCCESS,
+    payload: { genesisHash, sectorIdx }
+  }),
+  claimTreasureFailure: ({ genesisHash, sectorIdx }) => ({
+    type: TREASURE_HUNT_CLAIM_TREASURE_FAILURE,
     payload: { genesisHash, sectorIdx }
   })
 });

--- a/webnode/src/redux/epics/node-epics.js
+++ b/webnode/src/redux/epics/node-epics.js
@@ -73,12 +73,12 @@ const genesisHashOrTreasureHuntEpic = (action$, store) => {
         return of(nodeActions.requestGenesisHashes());
       } else {
         const { genesisHash, numberOfChunks } = treasureHuntableGenesisHash;
-        const { index } = treasureHuntableSector;
+        const sectorIdx = treasureHuntableSector;
         return of(
           nodeActions.resumeOrStartNewSector({
-            genesisHash: genesisHash,
-            numberOfChunks: numberOfChunks,
-            sectorIdx: index
+            genesisHash,
+            numberOfChunks,
+            sectorIdx
           })
         );
       }
@@ -98,7 +98,9 @@ const resumeOrStartNewSectorEpic = (action$, store) => {
       const sectorsFirstChunkIdx = sectorIdx * CHUNKS_PER_SECTOR;
 
       const alreadyStartedSector =
-        chunkIdx > sectorsFirstChunkIdx && currentSectorIdx === sectorIdx && genesisHash === currentGenesisHash;
+        chunkIdx > sectorsFirstChunkIdx &&
+        currentSectorIdx === sectorIdx &&
+        genesisHash === currentGenesisHash;
 
       return alreadyStartedSector
         ? of(treasureHuntActions.performPow())
@@ -122,7 +124,10 @@ const requestBrokerEpic = (action$, store) => {
       brokerNode.requestBrokerNodeAddressPoW({ brokerNodeUrl, currentList })
     )
       .mergeMap(({ data }) => {
-        const { id: txid, pow: { message, address, branchTx, trunkTx } } = data;
+        const {
+          id: txid,
+          pow: { message, address, branchTx, trunkTx }
+        } = data;
 
         // TODO: change this
         const value = 0;
@@ -257,7 +262,7 @@ const checkIfSectorClaimedEpic = (action$, store) => {
       return fromPromise(iota.checkIfClaimed(address)).map(
         claimed =>
           claimed
-            ? nodeActions.markSectorAsClaimed({
+            ? nodeActions.updateSectorStatus({
                 genesisHash,
                 sectorIdx
               })
@@ -271,9 +276,9 @@ const checkIfSectorClaimedEpic = (action$, store) => {
     });
 };
 
-const markSectorAsClaimedEpic = (action$, store) => {
+const updateSectorStatusEpic = (action$, store) => {
   return action$
-    .ofType(nodeActions.NODE_MARK_SECTOR_AS_CLAIMED)
+    .ofType(nodeActions.NODE_UPDATE_SECTOR_STATUS)
     .map(nodeActions.determineGenesisHashOrTreasureHunt);
 };
 
@@ -285,5 +290,5 @@ export default combineEpics(
   requestGenesisHashEpic,
   resumeOrStartNewSectorEpic,
   checkIfSectorClaimedEpic,
-  markSectorAsClaimedEpic
+  updateSectorStatusEpic
 );

--- a/webnode/src/redux/epics/node-epics.test.js
+++ b/webnode/src/redux/epics/node-epics.test.js
@@ -14,7 +14,7 @@ import nodeSelectors from "../selectors/node-selectors";
 
 import { SECTOR_STATUS } from "../../config";
 
-const { UNCLAIMED, SEARCHING, TREASURE_FOUND, CLAIMED } = SECTOR_STATUS;
+const { UNCLAIMED, CLAIMED } = SECTOR_STATUS;
 
 const mockStore = configureMockStore([]);
 
@@ -25,24 +25,16 @@ test("registerWebnodeEpic", () => {
       brokerNodes: [],
       newGenesisHashes: [
         {
-          genesisHash: "genesisHash bad",
-          sectorIdx: 4,
-          sectors: [{ index: 44, status: CLAIMED }]
+          genesisHash: "claimed 1",
+          sectors: [CLAIMED]
         },
         {
-          genesisHash: "genesisHash 1",
-          sectorIdx: 1,
-          sectors: [{ index: 11, status: UNCLAIMED }]
+          genesisHash: "unclaimed 1",
+          sectors: [UNCLAIMED]
         },
         {
-          genesisHash: "genesisHash 2",
-          sectorIdx: 2,
-          sectors: [{ index: 22, status: SEARCHING }]
-        },
-        {
-          genesisHash: "genesisHash 3",
-          sectorIdx: 3,
-          sectors: [{ index: 33, status: TREASURE_FOUND }]
+          genesisHash: "claimed 2",
+          sectors: [CLAIMED]
         }
       ],
       oldGenesisHashes: [],
@@ -85,14 +77,12 @@ test("brokerNodeOrGenesisHashEpic", () => {
     node: {
       brokerNodes: [
         {
-          genesisHash: "genesisHash bad",
-          sectorIdx: 4,
-          sectors: [{ index: 44, status: CLAIMED }]
+          genesisHash: "claimed 1",
+          sectors: [CLAIMED]
         },
         {
-          genesisHash: "genesisHash 1",
-          sectorIdx: 1,
-          sectors: [{ index: 11, status: UNCLAIMED }]
+          genesisHash: "unclaimed 1",
+          sectors: [UNCLAIMED]
         }
       ]
     }
@@ -116,24 +106,16 @@ test("genesisHashOrTreasureHuntEpic", () => {
       brokerNodes: [],
       newGenesisHashes: [
         {
-          genesisHash: "genesisHash bad",
-          sectorIdx: 4,
-          sectors: [{ index: 44, status: CLAIMED }]
+          genesisHash: "claimed 1",
+          sectors: [CLAIMED]
         },
         {
-          genesisHash: "genesisHash 1",
-          sectorIdx: 1,
-          sectors: [{ index: 11, status: UNCLAIMED }]
+          genesisHash: "unclaimed 1",
+          sectors: [UNCLAIMED]
         },
         {
-          genesisHash: "genesisHash 2",
-          sectorIdx: 2,
-          sectors: [{ index: 22, status: SEARCHING }]
-        },
-        {
-          genesisHash: "genesisHash 3",
-          sectorIdx: 3,
-          sectors: [{ index: 33, status: TREASURE_FOUND }]
+          genesisHash: "claimed 2",
+          sectors: [CLAIMED]
         }
       ],
       oldGenesisHashes: [],
@@ -157,16 +139,16 @@ test("genesisHashOrTreasureHuntEpic", () => {
   );
 
   const { genesisHash, numberOfChunks } = treasureHuntableGenesisHash;
-  const { index } = treasureHuntableSector;
+  const sectorIdx = treasureHuntableSector;
 
   nodeEpics(action, store)
     .toArray()
     .subscribe(actions => {
       expect(actions).toEqual([
         nodeActions.resumeOrStartNewSector({
-          genesisHash: genesisHash,
-          numberOfChunks: numberOfChunks,
-          sectorIdx: index
+          genesisHash,
+          numberOfChunks,
+          sectorIdx
         })
       ]);
     });
@@ -213,7 +195,11 @@ test("resumeOrStartNewSectorEpic", () => {
     });
 
   state = {
-    treasureHunt: { sectorIdx: 1, chunkIdx: 1 }
+    treasureHunt: {
+      sectorIdx: 1,
+      chunkIdx: 1,
+      genesisHash: "somethingDifferent"
+    }
   };
 
   store = mockStore(state);
@@ -286,20 +272,20 @@ test("requestGenesisHashEpic", () => {
     });
 });
 
-test("markSectorAsClaimedEpic", () => {
+test("updateSectorStatusEpic", () => {
   let state = {};
 
   let store = mockStore(state);
 
   const action = ActionsObservable.of({
-    type: nodeActions.NODE_MARK_SECTOR_AS_CLAIMED
+    type: nodeActions.NODE_UPDATE_SECTOR_STATUS
   });
 
   nodeEpics(action, store)
     .toArray()
     .subscribe(actions => {
       expect(actions).toEqual([
-        {"type": nodeActions.NODE_DETERMINE_GENESIS_HASH_OR_TREASURE_HUNT}
+        { type: nodeActions.NODE_DETERMINE_GENESIS_HASH_OR_TREASURE_HUNT }
       ]);
     });
 });

--- a/webnode/src/redux/epics/treasure-hunt-epics.test.js
+++ b/webnode/src/redux/epics/treasure-hunt-epics.test.js
@@ -11,12 +11,13 @@ import nodeActions from "../actions/node-actions";
 import treasureHuntActions from "../actions/treasure-hunt-actions";
 import treasureHuntEpics from "./treasure-hunt-epics";
 
-import { CHUNKS_PER_SECTOR } from "../../config/";
+import { CHUNKS_PER_SECTOR, SECTOR_STATUS } from "../../config/";
 
 import util from "node-forge/lib/util";
 
 import Datamap from "datamap-generator";
 
+const { CLAIMED, NO_TREASURE_FOUND } = SECTOR_STATUS;
 const mockStore = configureMockStore([]);
 
 test("performPowEpic", () => {
@@ -211,7 +212,39 @@ test("completeSectorEpic", () => {
     .toArray()
     .subscribe(actions => {
       expect(actions).toEqual([
-        nodeActions.markSectorAsClaimed({ genesisHash, sectorIdx })
+        nodeActions.updateSectorStatus({
+          genesisHash,
+          sectorIdx,
+          status: CLAIMED
+        })
+      ]);
+    });
+});
+
+test("failedSectorEpic", () => {
+  const genesisHash = "genesisHash";
+  const sectorIdx = 1;
+  const state = {};
+
+  const store = mockStore(state);
+
+  const action = ActionsObservable.of({
+    type: treasureHuntActions.TREASURE_HUNT_CLAIM_TREASURE_FAILURE,
+    payload: {
+      genesisHash: genesisHash,
+      sectorIdx: sectorIdx
+    }
+  });
+
+  treasureHuntEpics(action, store)
+    .toArray()
+    .subscribe(actions => {
+      expect(actions).toEqual([
+        nodeActions.updateSectorStatus({
+          genesisHash,
+          sectorIdx,
+          status: NO_TREASURE_FOUND
+        })
       ]);
     });
 });

--- a/webnode/src/redux/reducers/node-reducer.js
+++ b/webnode/src/redux/reducers/node-reducer.js
@@ -17,13 +17,7 @@ const brokerNodeGenerator = address => {
 
 const newGenesisHashGenerator = (genesisHash, numberOfChunks) => {
   const numberOfSectors = Math.ceil(numberOfChunks / CHUNKS_PER_SECTOR);
-  const sectorIdxes = Array.from(new Array(numberOfSectors), (_x, i) => i);
-  const sectors = sectorIdxes.map(index => {
-    return {
-      index,
-      status: SECTOR_STATUS.UNCLAIMED
-    };
-  });
+  const sectors = Array(numberOfSectors).fill(SECTOR_STATUS.UNCLAIMED);
   return { genesisHash, numberOfChunks, sectors };
 };
 
@@ -63,24 +57,17 @@ export default (state = initState, action) => {
         oldGenesisHashes: []
       };
 
-    case nodeActions.NODE_MARK_SECTOR_AS_CLAIMED:
+    case nodeActions.NODE_UPDATE_SECTOR_STATUS:
       const { genesisHash: gh, sectorIdx } = action.payload;
       const updatedGenesisHashes = state.newGenesisHashes.map(
         newGenesisHash => {
           if (newGenesisHash.genesisHash === gh) {
-            const updatedSectors = newGenesisHash.sectors.map(sector => {
-              if (sector.index === sectorIdx) {
-                return {
-                  ...sector,
-                  status: SECTOR_STATUS.CLAIMED
-                };
-              } else {
-                return { ...sector };
-              }
-            });
+            const updatedSectors = newGenesisHash.sectors.map(
+              (status, i) => (i === sectorIdx ? SECTOR_STATUS.CLAIMED : status)
+            );
             return { ...newGenesisHash, sectors: updatedSectors };
           } else {
-            return { ...newGenesisHash };
+            return newGenesisHash;
           }
         }
       );

--- a/webnode/src/redux/reducers/node-reducer.test.js
+++ b/webnode/src/redux/reducers/node-reducer.test.js
@@ -1,7 +1,8 @@
-import { CHUNKS_PER_SECTOR, SECTOR_STATUS } from "../../config/";
-
 import node from "./node-reducer";
 import nodeActions from "../actions/node-actions";
+
+import { CHUNKS_PER_SECTOR, SECTOR_STATUS } from "../../config/";
+const { CLAIMED, UNCLAIMED } = SECTOR_STATUS;
 
 const brokerNodeGenerator = address => {
   return { address };
@@ -9,17 +10,11 @@ const brokerNodeGenerator = address => {
 
 const newGenesisHashGenerator = (genesisHash, numberOfChunks) => {
   const numberOfSectors = Math.ceil(numberOfChunks / CHUNKS_PER_SECTOR);
-  const sectorIdxes = Array.from(new Array(numberOfSectors), (_x, i) => i);
-  const sectors = sectorIdxes.map(index => {
-    return {
-      index,
-      status: SECTOR_STATUS.UNCLAIMED
-    };
-  });
+  const sectors = Array(numberOfSectors).fill(SECTOR_STATUS.UNCLAIMED);
   return { genesisHash, numberOfChunks, sectors };
 };
 
-test("node-reducer NODE_MARK_SECTOR_AS_CLAIMED", () => {
+test("node-reducer NODE_UPDATE_SECTOR_STATUS", () => {
   const genesisHash = "genesisHash";
   const sectorIdx = 2;
   const lastResetAt = new Date();
@@ -30,7 +25,7 @@ test("node-reducer NODE_MARK_SECTOR_AS_CLAIMED", () => {
       {
         genesisHash: genesisHash,
         sectorIdx: sectorIdx,
-        sectors: [{ index: sectorIdx }]
+        sectors: [CLAIMED, CLAIMED, UNCLAIMED]
       }
     ],
     oldGenesisHashes: [],
@@ -39,7 +34,7 @@ test("node-reducer NODE_MARK_SECTOR_AS_CLAIMED", () => {
   };
 
   const action = {
-    type: nodeActions.NODE_MARK_SECTOR_AS_CLAIMED,
+    type: nodeActions.NODE_UPDATE_SECTOR_STATUS,
     payload: {
       genesisHash: genesisHash,
       sectorIdx: sectorIdx
@@ -52,7 +47,7 @@ test("node-reducer NODE_MARK_SECTOR_AS_CLAIMED", () => {
       {
         genesisHash: genesisHash,
         sectorIdx: sectorIdx,
-        sectors: [{ index: sectorIdx, status: SECTOR_STATUS.CLAIMED }]
+        sectors: [CLAIMED, CLAIMED, CLAIMED]
       }
     ],
     oldGenesisHashes: [],

--- a/webnode/src/redux/reducers/treasure-hunt-reducer.js
+++ b/webnode/src/redux/reducers/treasure-hunt-reducer.js
@@ -23,9 +23,7 @@ export default (state = initState, action) => {
       if (genesisHash === state.genesisHash && sectorIdx === state.sectorIdx) {
         // start from where webnode left off if it's the same
         // genesis hash and same sector index
-        return {
-          ...state
-        };
+        return state;
       } else {
         const sectorStartingIdx = sectorIdx * CHUNKS_PER_SECTOR;
         return {

--- a/webnode/src/redux/selectors/node-selectors.js
+++ b/webnode/src/redux/selectors/node-selectors.js
@@ -8,11 +8,8 @@ const getBrokerNodes = state => state.node.brokerNodes;
 
 const treasureHuntableGenesisHash = createSelector(
   [getNewGenesisHashes],
-  newGenesisHashes => {
-    return newGenesisHashes.find(gh => {
-      return gh.sectors.find(sector => sector.status === UNCLAIMED);
-    });
-  }
+  newGenesisHashes =>
+    newGenesisHashes.find(gh => gh.sectors.includes(UNCLAIMED))
 );
 
 const treasureHuntableSector = createSelector(
@@ -22,7 +19,7 @@ const treasureHuntableSector = createSelector(
       return null;
     }
 
-    return genesisHash.sectors.find(sector => sector.status === UNCLAIMED);
+    return genesisHash.sectors.findIndex(status => status === UNCLAIMED);
   }
 );
 

--- a/webnode/src/redux/selectors/node-selectors.test.js
+++ b/webnode/src/redux/selectors/node-selectors.test.js
@@ -1,7 +1,7 @@
 import { API_ROOT_URL, SECTOR_STATUS } from "../../config/";
 import nodeSelectors from "./node-selectors";
 
-const { UNCLAIMED, SEARCHING, TREASURE_FOUND, CLAIMED } = SECTOR_STATUS;
+const { UNCLAIMED, CLAIMED } = SECTOR_STATUS;
 
 test("node-selectors", () => {
   const lastResetAt = new Date();
@@ -10,24 +10,16 @@ test("node-selectors", () => {
       brokerNodes: [{ address: "first address" }, { address: "b" }],
       newGenesisHashes: [
         {
-          genesisHash: "genesisHash bad",
-          sectorIdx: 4,
-          sectors: [{ index: 44, status: CLAIMED }]
+          genesisHash: "claimed 1",
+          sectors: [CLAIMED]
         },
         {
-          genesisHash: "genesisHash 1",
-          sectorIdx: 1,
-          sectors: [{ index: 11, status: UNCLAIMED }]
+          genesisHash: "unclaimed 1",
+          sectors: [CLAIMED, UNCLAIMED]
         },
         {
-          genesisHash: "genesisHash 2",
-          sectorIdx: 2,
-          sectors: [{ index: 22, status: SEARCHING }]
-        },
-        {
-          genesisHash: "genesisHash 3",
-          sectorIdx: 3,
-          sectors: [{ index: 33, status: TREASURE_FOUND }]
+          genesisHash: "claimed 2",
+          sectors: [CLAIMED]
         }
       ],
       oldGenesisHashes: [],
@@ -37,15 +29,11 @@ test("node-selectors", () => {
   };
 
   const treasureHuntableGenesisHashExpected = {
-    genesisHash: "genesisHash 1",
-    sectorIdx: 1,
-    sectors: [{ index: 11, status: "UNCLAIMED" }]
+    genesisHash: "unclaimed 1",
+    sectors: [CLAIMED, UNCLAIMED]
   };
 
-  const treasureHuntableSectorExpected = {
-    index: 11,
-    status: "UNCLAIMED"
-  };
+  const treasureHuntableSectorExpected = 1;
 
   const brokerNodeUrlExpected = "first address";
   expect(nodeSelectors.treasureHuntableGenesisHash(state)).toEqual(
@@ -56,9 +44,7 @@ test("node-selectors", () => {
     treasureHuntableSectorExpected
   );
 
-  expect(nodeSelectors.brokerNodeUrl(state)).toEqual(
-    brokerNodeUrlExpected
-  );
+  expect(nodeSelectors.brokerNodeUrl(state)).toEqual(brokerNodeUrlExpected);
 
   state = {
     node: {
@@ -66,7 +52,5 @@ test("node-selectors", () => {
     }
   };
 
-  expect(nodeSelectors.brokerNodeUrl(state)).toEqual(
-    API_ROOT_URL
-  );
+  expect(nodeSelectors.brokerNodeUrl(state)).toEqual(API_ROOT_URL);
 });


### PR DESCRIPTION
- Unhappy path for when no treasure is found in sector
- Simplify genesis hash data structure from

`{ ..., sectors: [{ index: 0, status: "CLAIMED" }, { index: 1, status: "UNCLAIMED" } ...] }`

to

`{ ..., sectors: ["CLAIMED", "UNCLAIMED", ...] }`